### PR TITLE
Make logger dependency optional

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -5,9 +5,12 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
+// noopLogger is a logger that will do nothing.
 type noopLogger struct {
 }
 
 func (_ noopLogger) Printf(format string, v ...interface{}) {
 	// do nothing.
 }
+
+var _ Logger = noopLogger{}

--- a/term.go
+++ b/term.go
@@ -37,18 +37,25 @@ type Stopper struct {
 	log Logger
 }
 
-// NewWithDefaultSignals creates a new instance of application component stopper.
-// invokes withSignals with syscall.SIGINT and syscall.SIGTERM as default signals.
+// NewWithDefaultSignals creates a new instance of component stopper.
+// Invokes withSignals with syscall.SIGINT and syscall.SIGTERM as default signals.
+//
+// If the log parameter is nil, then noop logger will be used.
 //
 // Note: this method will start internal monitoring goroutine.
 func NewWithDefaultSignals(appCtx context.Context, log Logger) (*Stopper, context.Context) {
 	return NewWithSignals(appCtx, log, defaultSignals...)
 }
 
-// NewWithSignals creates a new instance of application component stopper.
+// NewWithSignals creates a new instance of component stopper.
+//
+// If the log parameter is nil, then noop logger will be used.
 //
 // Note: this method will start internal monitoring goroutine.
 func NewWithSignals(appCtx context.Context, log Logger, sig ...os.Signal) (*Stopper, context.Context) {
+	if log == nil {
+		log = noopLogger{}
+	}
 	chSignals := make(chan os.Signal, 1)
 	ctx, cancel := withSignals(appCtx, chSignals, sig...)
 	return &Stopper{

--- a/term_test.go
+++ b/term_test.go
@@ -28,21 +28,6 @@ func TestNewWithDefaultSignals(t *testing.T) {
 	require.NotNil(t, got.log)
 }
 
-func TestNewWithSignals(t *testing.T) {
-	rootCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	got, ctx := NewWithSignals(rootCtx, log.Default(), os.Interrupt)
-	require.NotNil(t, got)
-	require.NotNil(t, ctx)
-
-	require.NotNil(t, got.termComponentsMx)
-	require.NotNil(t, got.termComponents)
-	require.NotNil(t, got.wg)
-	require.NotNil(t, got.cancelFunc)
-	require.NotNil(t, got.log)
-}
-
 func TestStopper_AddShutdownHook(t *testing.T) {
 	t.Run("add_only_one_hook", func(t *testing.T) {
 		rootCtx, cancel := context.WithCancel(context.Background())
@@ -276,6 +261,52 @@ func Test_withSignals(t *testing.T) {
 			require.NotNil(t, gotCtx)
 			require.NotNil(t, gotCancelFunc)
 			require.NoError(t, gotCtx.Err())
+		})
+	}
+}
+
+func TestNewWithSignals(t *testing.T) {
+	type args struct {
+		log Logger
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "default_logger",
+			args: args{
+				log: log.Default(),
+			},
+		},
+		{
+			name: "private_noop_logger",
+			args: args{
+				log: log.Default(),
+			},
+		},
+		{
+			name: "nil_logger",
+			args: args{
+				log: nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			rootCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			got, ctx := NewWithSignals(rootCtx, tt.args.log, os.Interrupt)
+			require.NotNil(t, got)
+			require.NotNil(t, ctx)
+
+			require.NotNil(t, got.termComponentsMx)
+			require.NotNil(t, got.termComponents)
+			require.NotNil(t, got.wg)
+			require.NotNil(t, got.cancelFunc)
+			require.NotNil(t, got.log)
 		})
 	}
 }


### PR DESCRIPTION
Resort to default NOOP logger implementation, if provided one is `nil`