### PR TITLE
Skip golangci-lint cache on GitHub action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,9 +15,13 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
       - name: Vendoring Go dependencies
         run: go mod vendor
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: --timeout=5m


### PR DESCRIPTION
Explanation for these changes: https://github.com/golangci/golangci-lint-action/issues/244

This is just a workaround.