### PR TITLE
Restore signals, add pre-stop sleep

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -27,6 +27,7 @@ type Hook struct {
 
 	order    Order                     // order is Hook order.
 	name     string                    // name is an optional component name for pretty-printing in logs.
+	preStop  time.Duration             // time to wait _before_ triggering shutdown hook.
 	timeout  time.Duration             // timeout is max hookFunc execution timeout.
 	hookFunc func(ctx context.Context) // hookFunc is a user-defined termination hook function.
 }
@@ -37,6 +38,15 @@ type Hook struct {
 // to log internal termination lifecycle events.
 func (h *Hook) WithName(name string) *Hook {
 	h.name = name
+	return h
+}
+
+// WithPreStopSleep sets (optional) period between signal receive and shutdown hook call. It does not depend on hook timeout.
+//
+// This needed for correct graceful termination of network services in Kubernetes.
+// See https://blog.palark.com/graceful-shutdown-in-kubernetes-is-not-always-trivial/ for detailed information.
+func (h *Hook) WithPreStopSleep(t time.Duration) *Hook {
+	h.preStop = t
 	return h
 }
 

--- a/terminator.go
+++ b/terminator.go
@@ -55,6 +55,7 @@ func withSignals(ctx context.Context, chSignals chan os.Signal, sig ...os.Signal
 
 	// function invoke cancel once a signal arrived OR parent context is done:
 	go func() {
+		defer signal.Stop(chSignals)
 		defer cancel()
 
 		select {

--- a/terminator.go
+++ b/terminator.go
@@ -141,6 +141,10 @@ func (t *Terminator) waitShutdown(appCtx context.Context) {
 			go func(f Hook) {
 				defer runWg.Done()
 
+				if f.preStop > 0 {
+					time.Sleep(f.preStop)
+				}
+
 				ctx, cancel := context.WithTimeout(context.Background(), f.timeout)
 				defer cancel()
 


### PR DESCRIPTION
Changes in pull-request:
* Stop notification on signal channel after signal received. This recovers default signal behaviour (if no other notifiers registered) and allows to close application via `Ctrl-C` faster if any shutdown routine hangs.
* Add new option for hook to sleep before actual execution. This needed for correct termination in k8s. See https://blog.palark.com/graceful-shutdown-in-kubernetes-is-not-always-trivial/ for detailed description. 